### PR TITLE
Fix TestAssetDirective test

### DIFF
--- a/pyramid_zcml/tests/test_units.py
+++ b/pyramid_zcml/tests/test_units.py
@@ -632,6 +632,10 @@ class TestAssetDirective(unittest.TestCase):
         return asset(*arg, **kw)
 
     def test_it(self):
+        # This test is extremely fragile because it depends on internal API of
+        # the Pyramid asset_override function. This means that any changes in
+        # that API may cause this test to fail.
+        from pyramid.config.assets import PackageAssetSource
         from pyramid.registry import undefer
         import pyramid_zcml.tests
         context = DummyZCMLContext(self.config)
@@ -647,10 +651,11 @@ class TestAssetDirective(unittest.TestCase):
         discrim = undefer(actions[0]['discriminator'])
         self.assertEqual(action['discriminator'], None)
         action['callable']()
+        L = list(L[0])
         self.assertEqual(
-            L,
-            [(pyramid_zcml.tests, 'fixtures/', pyramid_zcml.tests,
-              'fixtureapp/')])
+            L[:2],
+            [pyramid_zcml.tests, 'fixtures/'])
+        self.assertTrue(isinstance(L[2], PackageAssetSource))
 
 
 class TestRendererDirective(unittest.TestCase):

--- a/pyramid_zcml/tests/test_units.py
+++ b/pyramid_zcml/tests/test_units.py
@@ -635,7 +635,6 @@ class TestAssetDirective(unittest.TestCase):
         # This test is extremely fragile because it depends on internal API of
         # the Pyramid asset_override function. This means that any changes in
         # that API may cause this test to fail.
-        from pyramid.config.assets import PackageAssetSource
         from pyramid.registry import undefer
         import pyramid_zcml.tests
         context = DummyZCMLContext(self.config)
@@ -655,7 +654,6 @@ class TestAssetDirective(unittest.TestCase):
         self.assertEqual(
             L[:2],
             [pyramid_zcml.tests, 'fixtures/'])
-        self.assertTrue(isinstance(L[2], PackageAssetSource))
 
 
 class TestRendererDirective(unittest.TestCase):


### PR DESCRIPTION
This test is using internal API within Pyramid that was changed in
Pyramid 1.6 (the default installed because it was released). This test
fixes the test to verify correctness, but because it is using internal
API the test is extremely brittle.

Closes #8 