### PR TITLE
Fix compatibility with Pyramid 1.8

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,8 @@
 - Add ``pyramid_mako`` testing dependency and configure it in tests
   (Current versions of Pyramid split out ``Mako`` integration).
 
+- Fix compatibility with Pyramid 1.8.
+
 1.0.0 (2013-02-28)
 ------------------
 

--- a/pyramid_zcml/__init__.py
+++ b/pyramid_zcml/__init__.py
@@ -23,7 +23,7 @@ from pyramid.authentication import RepozeWho1AuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
 from pyramid.exceptions import ConfigurationError
-from pyramid.asset import asset_spec_from_abspath
+from pyramid.asset import asset_spec_from_abspath, resolve_asset_spec
 from pyramid.threadlocal import get_current_registry
 
 from zope.configuration import xmlconfig
@@ -825,7 +825,7 @@ def load_zcml(self, spec='configure.zcml', lock=threading.Lock(), features=()):
     The ``features`` argument can be any iterable of strings. These are useful
     for conditionally including or excluding parts of a :term:`ZCML` file.
     """
-    package_name, filename = self._split_spec(spec)
+    package_name, filename = resolve_asset_spec(spec, self.package_name)
     if package_name is None: # absolute filename
         package = self.package
     else:

--- a/pyramid_zcml/tests/test_units.py
+++ b/pyramid_zcml/tests/test_units.py
@@ -130,7 +130,7 @@ class TestNotFoundDirective(unittest.TestCase):
         from zope.interface import implementedBy
         from pyramid.interfaces import IRequest
         from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IExceptionViewClassifier
         from pyramid.exceptions import NotFound
         from pyramid.registry import undefer
 
@@ -147,7 +147,7 @@ class TestNotFoundDirective(unittest.TestCase):
         register = actions[0]['callable']
         register()
         derived_view = reg.adapters.lookup(
-            (IViewClassifier, IRequest, implementedBy(NotFound)),
+            (IExceptionViewClassifier, IRequest, implementedBy(NotFound)),
             IView, default=None)
 
         self.assertNotEqual(derived_view, None)
@@ -158,7 +158,7 @@ class TestNotFoundDirective(unittest.TestCase):
         from zope.interface import implementedBy
         from pyramid.interfaces import IRequest
         from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IExceptionViewClassifier
         from pyramid.exceptions import NotFound
         from pyramid.config import Configurator
         from pyramid.registry import undefer
@@ -179,7 +179,7 @@ class TestNotFoundDirective(unittest.TestCase):
         register = regadapt['callable']
         register()
         derived_view = reg.adapters.lookup(
-            (IViewClassifier, IRequest, implementedBy(NotFound)),
+            (IExceptionViewClassifier, IRequest, implementedBy(NotFound)),
             IView, default=None)
         self.assertNotEqual(derived_view, None)
         self.assertEqual(derived_view(None, None).body, b('OK'))
@@ -200,7 +200,7 @@ class TestForbiddenDirective(unittest.TestCase):
         from zope.interface import implementedBy
         from pyramid.interfaces import IRequest
         from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IExceptionViewClassifier
         from pyramid.exceptions import Forbidden
         from pyramid.registry import undefer
         reg = self.config.registry
@@ -217,7 +217,7 @@ class TestForbiddenDirective(unittest.TestCase):
         register = actions[0]['callable']
         register()
         derived_view = reg.adapters.lookup(
-            (IViewClassifier, IRequest, implementedBy(Forbidden)),
+            (IExceptionViewClassifier, IRequest, implementedBy(Forbidden)),
             IView, default=None)
 
         self.assertNotEqual(derived_view, None)
@@ -228,7 +228,7 @@ class TestForbiddenDirective(unittest.TestCase):
         from zope.interface import implementedBy
         from pyramid.interfaces import IRequest
         from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IExceptionViewClassifier
         from pyramid.exceptions import Forbidden
         from pyramid.config import Configurator
         from pyramid.registry import undefer
@@ -249,7 +249,7 @@ class TestForbiddenDirective(unittest.TestCase):
         register = regadapt['callable']
         register()
         derived_view = reg.adapters.lookup(
-            (IViewClassifier, IRequest, implementedBy(Forbidden)),
+            (IExceptionViewClassifier, IRequest, implementedBy(Forbidden)),
             IView, default=None)
         self.assertNotEqual(derived_view, None)
         self.assertEqual(derived_view(None, None).body, b('OK'))


### PR DESCRIPTION
This fixes #22, but there are 4 more test failures about derived_views which I don't understand yet.