### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -566,7 +566,7 @@ A combination of imperative configuration, declarative configuration via ZCML
 and scanning can be used to configure any application.  They are not mutually
 exclusive.
 
-Declarative configuraton was the more traditional form of configuration used
+Declarative configuration was the more traditional form of configuration used
 in Pyramid applications; the first releases of Pyramid and all releases of
 Pyramid's predecessor named repoze.bfg included ZCML in the core.  However,
 by virtue of this package, it has been externalized from the Pyramid core

--- a/docs/zcml/static.rst
+++ b/docs/zcml/static.rst
@@ -35,7 +35,7 @@ Attributes
   ``__no_permission_required__``.  The ``__no_permission_required__``
   string is a special sentinel which indicates that, even if a
   :term:`default permission` exists for the current application, the
-  static view should be renderered to completely anonymous users.
+  static view should be rendered to completely anonymous users.
   This default value is permissive because, in most web apps, static
   resources seldom need protection from viewing.  You should use this
   option only if you register a static view which points at a


### PR DESCRIPTION
There are small typos in:
- docs/narr.rst
- docs/zcml/static.rst

Fixes:
- Should read `rendered` rather than `renderered`.
- Should read `configuration` rather than `configuraton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md